### PR TITLE
TI-1627: Add document importer linking to map elements

### DIFF
--- a/documentGeom.go
+++ b/documentGeom.go
@@ -46,7 +46,7 @@ func (s *Server) readMongo() ([]documentGeometry, error) {
 	if err != nil {
 		panic(err)
 	}
-	return fetchMongoDBRecords(session)
+	return s.fetchMongoDBRecords(session)
 }
 
 func (s *Server) updatePostgres(documentGeometry *[]documentGeometry) error {

--- a/postgresDB.go
+++ b/postgresDB.go
@@ -2,7 +2,10 @@ package documentGeom
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+
+	"strings"
 
 	_ "github.com/lib/pq"
 )
@@ -25,6 +28,16 @@ func (x *PostgresDBConnection) connectionString(addDB bool) string {
 		conStr += fmt.Sprintf(" port=%v", x.Port)
 	}
 	return conStr
+}
+
+func (x *postgresDB) selectGeometry(tableName string, fieldName string, fieldValue string) (geom string, err error) {
+	r := strings.NewReplacer("<TABLE>", tableName, "<FIELD>", fieldName, "<VAL>", fieldValue)
+	sqlString := r.Replace("SELECT \"Geometry\" FROM \"<TABLE>\" WHERE \"<FIELD>\" = '<VAL>' LIMIT 1")
+	err = x.db.QueryRow(sqlString).Scan(&geom)
+	if err != nil {
+		return "", errors.New("selectGeometry: Could not find element for field and value")
+	}
+	return geom, nil
 }
 
 func (x *postgresDB) truncateDocumentGeometry() error {

--- a/postgresDB.go
+++ b/postgresDB.go
@@ -32,10 +32,10 @@ func (x *PostgresDBConnection) connectionString(addDB bool) string {
 
 func (x *postgresDB) selectGeometry(tableName string, fieldName string, fieldValue string) (geom string, err error) {
 	r := strings.NewReplacer("<TABLE>", tableName, "<FIELD>", fieldName, "<VAL>", fieldValue)
-	sqlString := r.Replace("SELECT \"Geometry\" FROM \"<TABLE>\" WHERE \"<FIELD>\" = '<VAL>' LIMIT 1")
+	sqlString := r.Replace(`SELECT "Geometry" FROM "<TABLE>" WHERE "<FIELD>" = '<VAL>' LIMIT 1`)
 	err = x.db.QueryRow(sqlString).Scan(&geom)
 	if err != nil {
-		return "", errors.New("selectGeometry: Could not find element for field and value")
+		return "", errors.New("selectGeometry: Could not find element for field and value -> " + err.Error())
 	}
 	return geom, nil
 }


### PR DESCRIPTION
Whenever the code comes across a MongoDB file entry that does not have X and Y coordinates, it attempts to retrieve it from the Postgres database by using the tablename, fieldname and fieldvalues.  It then updates the Mongo record to prevent future queries for the same file.